### PR TITLE
Demand doobie Put/Get as separate constraints

### DIFF
--- a/modules/doobie/src/main/scala/io/chrisdavenport/fuuid/doobie/implicits.scala
+++ b/modules/doobie/src/main/scala/io/chrisdavenport/fuuid/doobie/implicits.scala
@@ -7,6 +7,10 @@ import io.chrisdavenport.fuuid.FUUID
 
 object implicits {
 
-  implicit def FuuidType(implicit U: Meta[UUID]): Meta[FUUID] =
+  @deprecated(message = "Please use FuuidMeta instead.", since = "0.5.1")
+  def FuuidType(implicit U: Meta[UUID]): Meta[FUUID] =
+    FuuidMeta(U, U)
+
+  implicit def FuuidMeta(implicit A: Get[UUID], B: Put[UUID]): Meta[FUUID] =
     U.timap[FUUID](FUUID.fromUUID)(fuuid => FUUID.Unsafe.toUUID(fuuid))
 }


### PR DESCRIPTION
From the Doobie documentation on Meta,

>  It's important to understand that `Meta` should never be demanded by user methods; instead demand both `Get` and `Put`. The reason for this is that while `Meta` implies `Get` and `Put`, the presence of both `Get` and `Put` does *not* imply `Meta`.

This commit separates the constraints for the `FUUID` `Meta` instance, adding a new implicit definition and deprecating the old one.