### PR TITLE
Missing braces needed for Scala 3 to compile core

### DIFF
--- a/modules/core/src/main/scala-3/io/chrisdavenport/fuuid/FUUID.scala
+++ b/modules/core/src/main/scala-3/io/chrisdavenport/fuuid/FUUID.scala
@@ -110,7 +110,7 @@ object FUUID {
   import scala.compiletime.error
 
   private[FUUID] object Macros {
-    def fuuidLiteral(s: Expr[String])(using qctx: Quotes): Expr[FUUID] =
+    def fuuidLiteral(s: Expr[String])(using qctx: Quotes): Expr[FUUID] = {
       import qctx.reflect.*
       import quotes.reflect.report
 
@@ -137,6 +137,7 @@ object FUUID {
             pos
           )
       }
+    }
   }
 
   /**


### PR DESCRIPTION
For whatever reason significant identation doesn't seem to be doing the trick on here, and I can only get this to compile on Scala 3 if I add these braces. Is it just my machine?
<img width="644" alt="Screen Shot 2021-07-09 at 11 34 44" src="https://user-images.githubusercontent.com/6819701/125103303-bd122d00-e0cb-11eb-9d17-1f404c739643.png">
