### PR TITLE
(Fix) Update scala3-library, ... to 3.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.15, 2.13.6, 3.0.2]
+        scala: [2.12.15, 2.13.6, 3.1.2]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2]
+        scala: [3.1.2]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2]
+        scala: [3.1.2]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 val Scala213 = "2.13.6"
 val Scala212 = "2.12.15"
-val Scala3 = "3.0.2"
+val Scala3 = "3.1.2"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 

--- a/modules/core/src/main/scala-3/io/chrisdavenport/fuuid/FUUID.scala
+++ b/modules/core/src/main/scala-3/io/chrisdavenport/fuuid/FUUID.scala
@@ -120,7 +120,7 @@ object FUUID {
         case Inlined(_, _, Literal(StringConstant(s))) =>
           fromString(s)
             .fold(
-              e => report.throwError(e.getMessage.replace("UUID", "FUUID"), pos),
+              e => report.errorAndAbort(e.getMessage.replace("UUID", "FUUID"), pos),
               _ => {
                 '{
                   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
@@ -132,7 +132,7 @@ object FUUID {
               }
             )
         case _ =>
-          report.throwError(
+          report.errorAndAbort(
             """This method uses a macro to verify that a FUUID literal is valid. Use FUUID.fromString if you have a dynamic value you want to parse as an FUUID.""",
             pos
           )


### PR DESCRIPTION
[https://github.com/davenverse/fuuid/pull/493](https://github.com/davenverse/fuuid/pull/493) is blocked due `quotes.reflect.report.throwError` beeing deprecated in scala `3.1.2`.

The fix is to use `quotes.reflect.report.errorAndAbort` (which is suggested in the deprecation message). 

Also note that it works on my local for scala `3.1.3` also, but I'll let scala-steward handle that :wink: